### PR TITLE
List planned reuploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Or install it yourself as:
    ```
 1. Run the rake task:
    ```bash
-     rake nochmal:reupload REUPLOAD_FROM=local REUPLOAD_TO=remote
+     rake nochmal:reupload REUPLOAD_FROM=local REUPLOAD_TO=remote # or rake nochmal:reupload[local,remote]
    ```
 
 ## Project Scope

--- a/lib/nochmal/output.rb
+++ b/lib/nochmal/output.rb
@@ -16,11 +16,16 @@ module Nochmal
         puts model_footer
       end
 
-      def type(type, count)
+      def type(type, count, mode)
         puts type_header(type)
-        print attachment_summary(count)
+        action = "#{ActiveSupport::Inflector.titleize(mode)}ing" # Listing, Processing, Reuploading
+        print attachment_summary(count, action)
         yield
         puts type_footer
+      end
+
+      def attachment(blob)
+        puts attachment_detail(blob)
       end
 
       def print_progress_indicator
@@ -50,8 +55,12 @@ module Nochmal
         "  Type #{green(type)}"
       end
 
-      def attachment_summary(count)
-        "    Reuploading #{count} #{"attachment".pluralize(count)}: "
+      def attachment_summary(count, action)
+        "    #{action} #{count} #{"attachment".pluralize(count)}: "
+      end
+
+      def attachment_detail(blob)
+        "      - #{blob.key}"
       end
 
       def type_footer

--- a/lib/nochmal/output.rb
+++ b/lib/nochmal/output.rb
@@ -16,16 +16,15 @@ module Nochmal
         puts model_footer
       end
 
-      def type(type, count, mode)
+      def type(type, count, action)
         puts type_header(type)
-        action = "#{ActiveSupport::Inflector.titleize(mode)}ing" # Listing, Processing, Reuploading
         print attachment_summary(count, action)
         yield
         puts type_footer
       end
 
-      def attachment(blob)
-        puts attachment_detail(blob)
+      def attachment(filename)
+        print attachment_detail(filename)
       end
 
       def print_progress_indicator
@@ -56,11 +55,11 @@ module Nochmal
       end
 
       def attachment_summary(count, action)
-        "    #{action} #{count} #{"attachment".pluralize(count)}: "
+        "    Going to #{action} #{count} #{"attachment".pluralize(count)}: "
       end
 
-      def attachment_detail(blob)
-        "      - #{blob.key}"
+      def attachment_detail(filename)
+        "\n      - #{filename}"
       end
 
       def type_footer

--- a/lib/nochmal/reupload.rb
+++ b/lib/nochmal/reupload.rb
@@ -10,8 +10,8 @@ module Nochmal
 
     def initialize(from:, to: nil, helper: nil)
       @active_storage = helper || ActiveStorageHelper.new
-      @from_service = active_storage.storage_service(from.to_sym)
-      @to_service = active_storage.storage_service(to&.to_sym)
+      @from_service = active_storage.from_storage_service(from.to_sym)
+      @to_service = active_storage.to_storage_service(to&.to_sym)
     end
 
     def all

--- a/lib/nochmal/reupload.rb
+++ b/lib/nochmal/reupload.rb
@@ -52,6 +52,7 @@ module Nochmal
 
     def reupload_type(model, type)
       collection = model.send("with_attached_#{type}")
+      return false unless collection.table_exists?
 
       Output.type(type, collection.count, @mode) do
         collection.find_each do |item|

--- a/lib/nochmal/reupload.rb
+++ b/lib/nochmal/reupload.rb
@@ -1,4 +1,4 @@
-#frozen_string_literal: true
+# frozen_string_literal: true
 
 module Nochmal
   # Handles Reuploading of all attachments
@@ -15,14 +15,20 @@ module Nochmal
     end
 
     def all
-      Output.reupload(models) do
-        models.each do |model|
-          reupload_model(model)
-        end
+      each_model do |model|
+        reupload_model(model)
       end
     end
 
     private
+
+    def each_model(&block)
+      raise ArgumentError, "Please pass a block to handle each model" unless block_given?
+
+      Output.reupload(models) do
+        models.each(&block)
+      end
+    end
 
     def models
       active_storage.models_with_attachments

--- a/lib/tasks/nochmal.rake
+++ b/lib/tasks/nochmal.rake
@@ -4,9 +4,13 @@ require_relative "../nochmal/reupload"
 
 namespace :nochmal do
   desc "Reuploads attachments from ENV['REUPLOAD_FROM'] to ENV['REUPLOAD_TO'] or configured active_storage service"
-  task reupload: :environment do
-    from = ENV["REUPLOAD_FROM"] || raise("The ENV variable REUPLOAD_FROM is required")
-    to = ENV["REUPLOAD_TO"]
+  task :reupload, %i[from to] => :environment do |_t, args|
+    from = args[:from] ||
+           ENV["REUPLOAD_FROM"] ||
+           raise("The ENV variable REUPLOAD_FROM is required")
+
+    to = args[:to] ||
+         ENV["REUPLOAD_TO"]
 
     Nochmal::Reupload.new(from: from, to: to).all
   end

--- a/lib/tasks/nochmal.rake
+++ b/lib/tasks/nochmal.rake
@@ -14,4 +14,13 @@ namespace :nochmal do
 
     Nochmal::Reupload.new(from: from, to: to).all
   end
+
+  desc "List attachments that would be reuploaded from ENV['REUPLOAD_FROM']"
+  task :list, [:from] => :environment do |_t, args|
+    from = args[:from] ||
+           ENV["REUPLOAD_FROM"] ||
+           raise("The ENV variable REUPLOAD_FROM is required")
+
+    Nochmal::Reupload.new(from: from).list
+  end
 end

--- a/spec/lib/nochmal/output_spec.rb
+++ b/spec/lib/nochmal/output_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Nochmal::Output do
 
   describe "#type" do
     subject(:type) do
-      described_class.type(object, count) { object.test }
+      described_class.type(object, count, :reupload) { object.test }
     end
 
     let(:object) { instance_double("Test1") }

--- a/spec/lib/nochmal/reupload_spec.rb
+++ b/spec/lib/nochmal/reupload_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Nochmal::Reupload do
   def stub_models
     allow(models).to receive(:count).and_return(10)
     allow(models).to receive(:find_each).and_yield(model)
+    allow(models).to receive(:table_exists?).and_return(true)
     allow(model).to receive(:with_attached_avatar).and_return(models)
     allow(model).to receive(:avatar).and_return(type)
     allow(type).to receive(:to_str).and_return("avatar")


### PR DESCRIPTION
This adds a bunch of small details. Most importantly, it can now list found reuploads. This works as a "dry-run" of sorts and helps to plan for storage and to develop new features.